### PR TITLE
Page title change from ANSYS to Ansys

### DIFF
--- a/module_wiki_page.json
+++ b/module_wiki_page.json
@@ -1,9 +1,9 @@
 {
     "abaqus": "Abaqus",
     "abinit": "ABINIT",
-    "ansys": "ANSYS",
-    "fluent": "ANSYS",
-    "cfx": "ANSYS",
+    "ansys": "Ansys",
+    "fluent": "Ansys",
+    "cfx": "Ansys",
     "spark": "Apache Spark",
     "cuda": "CUDA",
     "cpmd": "CPMD",


### PR DESCRIPTION
To conform to vendor's typography, https://www.ansys.com/