### PR TITLE
Start spider from /cvmfs/soft.computecanada.ca/custom/modules

### DIFF
--- a/cvmfs-client-dev.cfg
+++ b/cvmfs-client-dev.cfg
@@ -1,5 +1,4 @@
 [Configuration]
 style = lmod
 command = /cvmfs/soft.computecanada.ca/nix/var/nix/profiles/16.09/lmod/lmod/libexec/spider -o spider-json
-paths = /cvmfs/soft.computecanada.ca/easybuild/modules/2017/Core /cvmfs/soft.computecanada.ca/easybuild/modules/2020/Core /cvmfs/soft.computecanada.ca/easybuild/modules/2023/Core
-
+paths = /cvmfs/soft.computecanada.ca/custom/modules

--- a/modules.py
+++ b/modules.py
@@ -117,7 +117,7 @@ def LmodModuleList(paths):
                     type = module_data["propT"]["type_"].keys()[0]
                 newModule = Module(name,help,"-",_prereq_list=[prereq],_type=type,wiki_url_list=wiki_url_list)
                 newModule.name = module_name
-                if newModule.version[0] != ".":
+                if newModule.version[0] != "." and not module_data.get("hidden") and "whatis" in module_data:
                     found = False
                     new_version = ""
                     for n,m in enumerate(moduleList):


### PR DESCRIPTION
This avoids needing seperate per-arch files, and automatically causes the spider to skip nixpkgs-dependent modules, as it does on clusters already.